### PR TITLE
Add a GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/test-2021.yml
+++ b/.github/workflows/test-2021.yml
@@ -1,0 +1,31 @@
+name: "2021 Advent of Code"
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-11
+            python-version: 3.8
+          - os: ubuntu-latest
+            python-version: 3.9
+
+    defaults:
+      run:
+        working-directory: "2021"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Test with pytest
+        run: |
+          pytest


### PR DESCRIPTION
This adds a GitHub Actions workflow to test on my two dev machines.

* macOS 11 with Python 3.8, close to my work laptop
* Ubuntu latest with Python 3.9, close to my work desktop